### PR TITLE
Add KaTeX preview mode

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0",
     "react-split-pane": "^0.1.92"
+    ,"katex": "^0.16.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/playground/src/components/LatexPreview.jsx
+++ b/playground/src/components/LatexPreview.jsx
@@ -1,0 +1,25 @@
+import React, { useMemo } from 'react'
+import katex from 'katex'
+import 'katex/dist/katex.min.css'
+
+const LatexPreview = ({ code = '' }) => {
+  const html = useMemo(() => {
+    try {
+      return katex.renderToString(code, {
+        throwOnError: false,
+        displayMode: true
+      })
+    } catch (err) {
+      return `<pre>${code.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`
+    }
+  }, [code])
+
+  return (
+    <div
+      style={{ padding: '1rem', overflow: 'auto', height: '100%', background: '#fff', color: '#000' }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}
+
+export default LatexPreview

--- a/playground/src/pages/TexSnipEditor.jsx
+++ b/playground/src/pages/TexSnipEditor.jsx
@@ -6,6 +6,7 @@ import React, {
     useImperativeHandle
   } from "react"
   import AceEditor from "react-ace"
+  import LatexPreview from "../components/LatexPreview"
   
   // Themes & Modes
   import "ace-builds/src-noconflict/theme-twilight"
@@ -24,6 +25,8 @@ import React, {
     const [parentTopic, setParentTopic] = useState("Ringe")
     const [content, setContent] = useState("")
     const [body, setBody] = useState("")
+
+    const [previewMode, setPreviewMode] = useState(false)
   
     const [freezeSubject, setFreezeSubject] = useState(true)
     const [freezeTopic, setFreezeTopic] = useState(true)
@@ -462,19 +465,28 @@ useEffect(() => {
         </div>
    
         {/* ACE Editor */}
+        <div style={{ textAlign: "right", marginBottom: "0.5rem" }}>
+          <button onClick={() => setPreviewMode(p => !p)} style={{ fontSize: "0.7rem", padding: "0.2rem 0.5rem" }}>
+            {previewMode ? "📝 Code" : "👁 Preview"}
+          </button>
+        </div>
         <div style={{ flex: 1 }}>
-          <AceEditor
-            ref={aceRef}
-            mode="latex_custom"
-            theme="twilight"
-            value={body}
-            onChange={setBody}
-            name="editor"
-            width="100%"
-            height="100%"
-            fontSize={12}
-            setOptions={{ useWorker: false, wrap: true }}
-          />
+          {previewMode ? (
+            <LatexPreview code={body} />
+          ) : (
+            <AceEditor
+              ref={aceRef}
+              mode="latex_custom"
+              theme="twilight"
+              value={body}
+              onChange={setBody}
+              name="editor"
+              width="100%"
+              height="100%"
+              fontSize={12}
+              setOptions={{ useWorker: false, wrap: true }}
+            />
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary
- add `katex` dependency
- implement `LatexPreview` component for rendered output
- allow switching between Ace editor and preview in `TexSnipEditor`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860fdd73fa88328b1f5bada79ea56dc